### PR TITLE
Remove unnecessary needle from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ This module will use SemVer, and will stay on v0.X for the foreseeable future
 | hosted\_zone\_domain\_name | Domain name of the hosted zone to create records in | `string` | n/a | yes |
 | hosted\_zone\_id | ID of Route53 hosted zone to create records in | `string` | n/a | yes |
 | instance\_type | Instance type to use for the cluster nodes | `string` | n/a | yes |
-| kubernetes\_version | Kubernetes version to use. Must be supported by the version of the RKE provider you are using. See https://github.com/rancher/terraform-provider-rke/releases | `string` | n/a | yes |
+| kubernetes\_version | Kubernetes version to use. Must be supported by the version of the RKE provider you are using. See [https://github.com/rancher/terraform-provider-rke/releases](https://github.com/rancher/terraform-provider-rke/releases) | `string` | n/a | yes |
 | name | Solution name | `string` | n/a | yes |
 | namespace | Namespace, which could be your organization name or abbreviation | `string` | n/a | yes |
 | node\_group\_1\_subnet\_id | Subnet to deploy node group 1 to | `string` | n/a | yes |
@@ -180,11 +180,11 @@ This module will use SemVer, and will stay on v0.X for the foreseeable future
 
 | Name | Description |
 |------|-------------|
-| cluster\_kubeconfig | [SENSITIVE] KUBECONFIG yaml file contents to connect to the cluster. DO NOT USE unless you have no other options. Users should use the KUBECONFIG that Rancher provides to them rather than this. |
+| cluster\_kubeconfig | KUBECONFIG yaml file contents to connect to the cluster. DO NOT USE unless you have no other options. Users should use the KUBECONFIG that Rancher provides to them rather than this. |
 | rancher\_admin\_password | Password for Rancher 'admin' user |
 | rancher\_admin\_token | API Token for Rancher 'admin' user |
 | rancher\_endpoint | Endpoint of Rancher Server |
-| ssh\_private\_key | [SENSITIVE] Cluster nodes' private SSH key |
+| ssh\_private\_key | Cluster nodes' private SSH key |
 | ssh\_public\_key | Cluster nodes' public SSH key |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-aws-rke-rancher-master-cluster
 
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/1a0da89e2ec443ed9de6d90eaa9bccd8)](https://www.codacy.com/gh/saic-oss/terraform-aws-rke-rancher-master-cluster/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=saic-oss/terraform-aws-rke-rancher-master-cluster&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/1a0da89e2ec443ed9de6d90eaa9bccd8)](https://www.codacy.com/gh/saic-oss/terraform-aws-rke-rancher-master-cluster/dashboard?utm_source=github.com&utm_medium=referral&utm_content=saic-oss/terraform-aws-rke-rancher-master-cluster&utm_campaign=Badge_Grade)
 
 Terraform module that creates an RKE cluster, meant to serve as nothing but a highly-available Rancher "master" cluster
 
@@ -163,7 +163,7 @@ This module will use SemVer, and will stay on v0.X for the foreseeable future
 | hosted\_zone\_domain\_name | Domain name of the hosted zone to create records in | `string` | n/a | yes |
 | hosted\_zone\_id | ID of Route53 hosted zone to create records in | `string` | n/a | yes |
 | instance\_type | Instance type to use for the cluster nodes | `string` | n/a | yes |
-| kubernetes\_version | Kubernetes version to use. Must be supported by the version of the RKE provider you are using. See [https://github.com/rancher/terraform-provider-rke/releases](https://github.com/rancher/terraform-provider-rke/releases) | `string` | n/a | yes |
+| kubernetes\_version | Kubernetes version to use. Must be supported by the version of the RKE provider you are using. See https://github.com/rancher/terraform-provider-rke/releases | `string` | n/a | yes |
 | name | Solution name | `string` | n/a | yes |
 | namespace | Namespace, which could be your organization name or abbreviation | `string` | n/a | yes |
 | node\_group\_1\_subnet\_id | Subnet to deploy node group 1 to | `string` | n/a | yes |
@@ -180,11 +180,11 @@ This module will use SemVer, and will stay on v0.X for the foreseeable future
 
 | Name | Description |
 |------|-------------|
-| cluster\_kubeconfig | KUBECONFIG yaml file contents to connect to the cluster. DO NOT USE unless you have no other options. Users should use the KUBECONFIG that Rancher provides to them rather than this. |
+| cluster\_kubeconfig | [SENSITIVE] KUBECONFIG yaml file contents to connect to the cluster. DO NOT USE unless you have no other options. Users should use the KUBECONFIG that Rancher provides to them rather than this. |
 | rancher\_admin\_password | Password for Rancher 'admin' user |
 | rancher\_admin\_token | API Token for Rancher 'admin' user |
 | rancher\_endpoint | Endpoint of Rancher Server |
-| ssh\_private\_key | Cluster nodes' private SSH key |
+| ssh\_private\_key | [SENSITIVE] Cluster nodes' private SSH key |
 | ssh\_public\_key | Cluster nodes' public SSH key |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!--lint disable-->
 # terraform-aws-rke-rancher-master-cluster
 
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/1a0da89e2ec443ed9de6d90eaa9bccd8)](https://www.codacy.com/gh/saic-oss/terraform-aws-rke-rancher-master-cluster/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=saic-oss/terraform-aws-rke-rancher-master-cluster&amp;utm_campaign=Badge_Grade)

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,13 +4,13 @@ output "ssh_public_key" {
 }
 
 output "ssh_private_key" {
-  description = "[SENSITIVE] Cluster nodes' private SSH key"
+  description = "Cluster nodes' private SSH key"
   value       = tls_private_key.ssh.private_key_pem
   sensitive   = true
 }
 
 output "cluster_kubeconfig" {
-  description = "[SENSITIVE] KUBECONFIG yaml file contents to connect to the cluster. DO NOT USE unless you have no other options. Users should use the KUBECONFIG that Rancher provides to them rather than this."
+  description = "KUBECONFIG yaml file contents to connect to the cluster. DO NOT USE unless you have no other options. Users should use the KUBECONFIG that Rancher provides to them rather than this."
   value       = rke_cluster.default.kube_config_yaml
   sensitive   = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,7 @@ variable "node_volume_size" {
 
 variable "kubernetes_version" {
   type        = string
-  description = "Kubernetes version to use. Must be supported by the version of the RKE provider you are using. See https://github.com/rancher/terraform-provider-rke/releases"
+  description = "Kubernetes version to use. Must be supported by the version of the RKE provider you are using. See [https://github.com/rancher/terraform-provider-rke/releases](https://github.com/rancher/terraform-provider-rke/releases)"
 }
 
 variable "hosted_zone_id" {


### PR DESCRIPTION
## what
Remove unnecessary needle from when we were trying to get markdown-lint inline ignores working

## why
It isn't looked at by Codacy

## references
n/a
