### PR TITLE
Change docker version to use 19.03.14

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ runcmd:
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - apt-get update
-  - apt-get -y install docker-ce docker-ce-cli containerd.io
+  - apt-get -y install docker-ce=5:19.03.14~3-0~ubuntu-bionic docker-ce-cli=5:19.03.14~3-0~ubuntu-bionic containerd.io
   - usermod -G docker -a ubuntu
   - echo '{"log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"6"}}' | jq . > /etc/docker/daemon.json
   - systemctl restart docker && systemctl enable docker


### PR DESCRIPTION
## what
* Added specific version of Docker to install

## why
* The commands were installing latest Docker release
* The latest Docker release (20.10.0) throws errors for the RKE cluster creation
